### PR TITLE
Ajouter un guide de contribution au projet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,19 @@
 # Comment contribuer ?
 
-Merci d'envisager de contribuer à notre projet de documentation de la manière de contribuer à WordPress.
+Merci d'envisager de contribuer à notre projet de documentation (en français) de la manière de contribuer à WordPress. Vous êtes tou·te·s les bienvenu·e·s pour nous aider dans la rédaction de cette documentation. Ce projet accompagne la [démarche participative](https://2019.paris.wordcamp.org/2018/11/06/premier-atelier-preparatoire-journee-contribution/) de préparation de la première **Journée de Contribution** du [WordCamp Paris](https://2019.paris.wordcamp.org) qui se déroulera le 24 avril 2019. Pour participer concrètement cette démarche, vous avez simplement besoin d'un compte sur GitHub.com et sur WordPress.org. Si toutefois vous ne disposez pas de l'un ou l'autre, voici les deux liens d'inscription sur ces deux sites :
+
+- https://github.com/join
+- https://login.wordpress.org/register?locale=fr_FR
+
+## Principe
+
+> La meilleure manière d'apprendre à contribuer, c'est de contribuer !
+
+C'est le principe que nous avons retenu pour la rédaction de cette documentation et c'est une des raisons pour lesquelles nous avons choisi de l'écrire sur GitHub.com. En effet, la contribution au noyau de WordPress (ou à certains thèmes et extensions matures) repose sur :
+
+- l'utilisation d'un [système de gestion du code source](https://fr.wikipedia.org/wiki/Gestion_de_versions) centralisé (ex: Subversion) ou décentralisé (ex: Git).
+- un outil de rapport et de suivi d'anomalies (la plupart des projets open source de WordPress utilise le logiciel [Trac](https://trac.edgewall.org/))
+
+En utilisant GitHub.com nous réunissons ces deux ingrédients en un seul et même "lieu" tout en profitant de la fonctionnalité de clonage de Git pour vous permettre de gagner en autonomie et en souplesse et nous faire gagner en efficacité quant à l'organisation de notre collaboration.
+
+Par ailleurs, nous pensons que c'est également un bon moyen de se familiariser avec la gestion des [anomalies ou demandes d'évolutions](https://github.com/WordCampParis/contribuer-a-wordpress/issues) ("ticket" pour WordPress.org, "issue" pour GitHub.com) et leur organisation au sein de [jalons](https://github.com/WordCampParis/contribuer-a-wordpress/milestones) ("Milestones" pour les deux).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Comment contribuer ?
+
+Merci d'envisager de contribuer à notre projet de documentation de la manière de contribuer à WordPress.


### PR DESCRIPTION
Pour permettre à toute personne de participer au projet de documentation, construire un guide de démarrage rapide.