### PR TITLE
Correction documentation VVV

### DIFF
--- a/logiciels/vvv.md
+++ b/logiciels/vvv.md
@@ -31,6 +31,7 @@ cd ~/vagrant-local
 ```
 
 Lancez VVV pour créer la machine virtuelle.
+(attention, sous Windows, il faut lancer l'invite de commandes via un clic droit puis "Exécuter en tant qu'administrateur")
 
 ```bash
 vagrant up

--- a/logiciels/vvv.md
+++ b/logiciels/vvv.md
@@ -15,6 +15,7 @@ Installez l'extension Host Updater grâce à cette ligne de commande :
 ```bash
 vagrant plugin install vagrant-hostsupdater
 ```
+(attention, sous Windows, il faut lancer l'invite de commandes que vous allez utiliser tout au long de ce tutoriel via un clic droit puis "Exécuter en tant qu'administrateur")
 
 ## Installer VVV
 
@@ -27,12 +28,10 @@ git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git ./vagrant-
 Positionnez-vous dans le répertoire `vagrant-local` (au lancement de Vagrant, le fichier `vvv-config.yml` sera automatiquement copié vers `vvv-custom.yml`, dans lequel vous pourrez éventuellement adapter la configuration de VVV.
 
 ```bash
-cd ~/vagrant-local
+cd ./vagrant-local
 ```
 
 Lancez VVV pour créer la machine virtuelle.
-(attention, sous Windows, il faut lancer l'invite de commandes via un clic droit puis "Exécuter en tant qu'administrateur")
-
 ```bash
 vagrant up
 ```

--- a/logiciels/vvv.md
+++ b/logiciels/vvv.md
@@ -21,14 +21,13 @@ vagrant plugin install vagrant-hostsupdater
 Clonez le dépôt master de VVV grâce à cette ligne de commande :
 
 ```bash
-git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git ~/vagrant-local
+git clone -b master git://github.com/Varying-Vagrant-Vagrants/VVV.git ./vagrant-local
 ```
 
-Positionnez-vous dans le répertoire `vagrant-local` puis effectuez une copie du fichier `vvv-config.yml` pour le coller sous le nom de `vvv-custom.yml`. C'est depuis ce deuxième fichier que vous pourrez éventuellement adapter la configuration de VVV.
+Positionnez-vous dans le répertoire `vagrant-local` (au lancement de Vagrant, le fichier `vvv-config.yml` sera automatiquement copié vers `vvv-custom.yml`, dans lequel vous pourrez éventuellement adapter la configuration de VVV.
 
 ```bash
 cd ~/vagrant-local
-cp vvv-config.yml vvv-custom.yml
 ```
 
 Lancez VVV pour créer la machine virtuelle.
@@ -37,7 +36,7 @@ Lancez VVV pour créer la machine virtuelle.
 vagrant up
 ```
 
-Une fois la série de commande terminée, vérifiez votre installation en vous rendant sur `http://vvv.test` ou `https://vvv.test` `*`.
+Une fois la série de commande terminée, vérifiez votre installation en vous rendant sur `http://vvv.test` ou `https://vvv.test`.
 
 ![Dashboard VVV](https://dl.dropboxusercontent.com/s/5w6x370wh1wc7w4/vvv.png)
 


### PR DESCRIPTION
- La commande de copie du .yml n'est plus nécessaire, elle est faite automatiquement par Vagrant
- L'utilisation du ~ pose problème sur des OS ne le gérant pas
- Les URLs comportent un * en trop à la fin